### PR TITLE
Update packages

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -212,7 +212,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         HashMap<String, Object> constants = new HashMap<String, Object>();
         int orientationInt = getReactApplicationContext().getResources().getConfiguration().orientation;
 
-        constants.put("initialOrientationInt", orientationInt);
+        constants.put("initialOrientationInt", this.getCCOrientationInt(orientationInt));
 
         String orientation = this.getOrientationString(orientationInt);
         if (orientation == "null") {
@@ -242,6 +242,21 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         } else {
             return "null";
         }
+    }
+
+    private int getCCOrientationInt(int orientation) {
+        int ccOrientationInt;
+        switch (orientation) {
+        case Configuration.ORIENTATION_LANDSCAPE:
+            ccOrientationInt = CC_CAMERA_ORIENTATION_LANDSCAPE_LEFT;
+            break;
+        case Configuration.ORIENTATION_PORTRAIT:
+            ccOrientationInt = CC_CAMERA_ORIENTATION_PORTRAIT;
+            break;
+        default:
+            ccOrientationInt = -1;
+        }
+        return ccOrientationInt;
     }
 
     @Override

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -163,6 +163,13 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @ReactMethod
+    public void getOrientationAsCCInt(Callback callback) {
+        final int orientationInt = getReactApplicationContext().getResources().getConfiguration().orientation;
+        int ccOrientationInt = this.getCCOrientationInt(orientationInt);
+        callback.invoke(null, ccOrientationInt);
+    }
+
+    @ReactMethod
     public void lockToPortrait() {
         final Activity activity = getCurrentActivity();
         if (activity == null) {

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -93,15 +93,22 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                 if (physOrientation != OrientationEventListener.ORIENTATION_UNKNOWN) {
 
                     Activity activity = rctContext.getCurrentActivity();
-                    int uiRotation = (activity == null)
-                            ? Surface.ROTATION_0
+                    int uiRotation = (activity == null) ? Surface.ROTATION_0
                             : activity.getWindowManager().getDefaultDisplay().getRotation();
                     int uiDegrees = 0;
                     switch (uiRotation) {
-                        case Surface.ROTATION_0:    uiDegrees = 0;    break;
-                        case Surface.ROTATION_90:   uiDegrees = 90;   break;
-                        case Surface.ROTATION_180:  uiDegrees = 180;  break;
-                        case Surface.ROTATION_270:  uiDegrees = 270;  break;
+                    case Surface.ROTATION_0:
+                        uiDegrees = 0;
+                        break;
+                    case Surface.ROTATION_90:
+                        uiDegrees = 90;
+                        break;
+                    case Surface.ROTATION_180:
+                        uiDegrees = 180;
+                        break;
+                    case Surface.ROTATION_270:
+                        uiDegrees = 270;
+                        break;
                     }
 
                     int relOrientation = (physOrientation + uiDegrees) % 360;
@@ -112,7 +119,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                     } else if (relOrientation < 125 && relOrientation >= 55) {
                         nextDeviceOrientation = CC_CAMERA_ORIENTATION_LANDSCAPE_RIGHT;
                     } else if (relOrientation < 215 && relOrientation >= 145) {
-                         nextDeviceOrientation = CC_CAMERA_ORIENTATION_PORTRAIT_UPSIDEDOWN;
+                        nextDeviceOrientation = CC_CAMERA_ORIENTATION_PORTRAIT_UPSIDEDOWN;
                     }
 
                     // System.out.println("[OrientationModule] Activity null? " + (activity == null ? "YES" : "NO"));
@@ -120,7 +127,8 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                 }
 
                 if (nextDeviceOrientation != mDeviceOrientation) {
-                    System.out.println("CCCameraOrientationChange: " + mDeviceOrientation + " -> " + nextDeviceOrientation);
+                    System.out.println(
+                            "CCCameraOrientationChange: " + mDeviceOrientation + " -> " + nextDeviceOrientation);
                     mDeviceOrientation = nextDeviceOrientation;
 
                     WritableMap params = Arguments.createMap();
@@ -203,6 +211,8 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     public @Nullable Map<String, Object> getConstants() {
         HashMap<String, Object> constants = new HashMap<String, Object>();
         int orientationInt = getReactApplicationContext().getResources().getConfiguration().orientation;
+
+        constants.put("initialOrientationInt", orientationInt);
 
         String orientation = this.getOrientationString(orientationInt);
         if (orientation == "null") {

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -10,7 +10,6 @@
 #endif
 
 @implementation Orientation
-@synthesize bridge = _bridge;
 
 static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllButUpsideDown;
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation {

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -323,6 +323,7 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
     NSString *orientationStr = [self getOrientationStr:orientation];
     
     return @{
+             @"initialOrientationInt": @(orientation),
              @"initialOrientation": orientationStr,
              @"orientationEnum": @{
                      @"portrait": @(CCCameraOrientationPortrait),

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -145,6 +145,29 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
     }
 }
 
+- (NSNumber *)getCCOrientationInt: (UIDeviceOrientation)orientation {
+    NSNumber *ccOrientationInt;
+    switch (orientation) {
+        case UIDeviceOrientationPortrait:
+            ccOrientationInt = @(CCCameraOrientationPortrait);
+            break;
+        case UIDeviceOrientationLandscapeLeft:
+            ccOrientationInt = @(CCCameraOrientationLandscapeLeft);
+            break;
+        case UIDeviceOrientationLandscapeRight:
+            ccOrientationInt = @(CCCameraOrientationLandscapeRight);
+            break;
+        case UIDeviceOrientationPortraitUpsideDown:
+            ccOrientationInt = @(CCCameraOrientationPortraitUpsideDown);
+            break;
+        default:
+            // use last known orientation (if FaceUp or FaceDown, or unknown)
+            ccOrientationInt = @(self.lastOrientation);
+            break;
+    }
+    return ccOrientationInt;
+}
+
 - (NSString *)getOrientationStr: (UIDeviceOrientation)orientation {
     NSString *orientationStr;
     switch (orientation) {
@@ -321,9 +344,10 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
     
     UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
     NSString *orientationStr = [self getOrientationStr:orientation];
+    NSNumber *ccOrientationInt = [self getCCOrientationInt:orientation];
     
     return @{
-             @"initialOrientationInt": @(orientation),
+             @"initialOrientationInt": ccOrientationInt,
              @"initialOrientation": orientationStr,
              @"orientationEnum": @{
                      @"portrait": @(CCCameraOrientationPortrait),

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -269,6 +269,13 @@ RCT_EXPORT_METHOD(getSpecificOrientation:(RCTResponseSenderBlock)callback)
     callback(@[[NSNull null], orientationStr]);
 }
 
+RCT_EXPORT_METHOD(getOrientationAsCCInt:(RCTResponseSenderBlock)callback)
+{
+    UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+    NSNumber *ccOrientationInt = [self getCCOrientationInt:orientation];
+    callback(@[[NSNull null], ccOrientationInt]);
+}
+
 RCT_EXPORT_METHOD(lockToPortrait)
 {
 #if DEBUG

--- a/index.js
+++ b/index.js
@@ -150,6 +150,10 @@ module.exports = {
     return Orientation.initialOrientation;
   },
 
+  getInitialOrientationInt() {
+    return Orientation.initialOrientationInt;
+  },
+
   getOrientations() {
     return Orientation.orientationEnum;
   }

--- a/index.js
+++ b/index.js
@@ -34,6 +34,12 @@ module.exports = {
     });
   },
 
+  getOrientationAsCCInt(cb) {
+    Orientation.getOrientationAsCCInt((error, orientation) => {
+      cb(error, orientation);
+    });
+  },
+
   getSpecificOrientation(cb) {
     Orientation.getSpecificOrientation((error, orientation) => {
       cb(error, orientation);


### PR DESCRIPTION
Hey guys, 

I made a few changes to this package. Mainly, I wanted to retrieve some values as your CCCameraOrientation values, since that's what the camera seems to mainly use.

- Added `getInitialOrientationInt()` — Just like `getInitialOrientation`, but returns a CCOrientation value instead of a string.
- Added `getOrientationAsCCInt()` — Just like `getOrientation()` but returns a CCOrientation value instead of a device-specific int.
- Removed `@synthesize bridge = _bridge;` from Orientation.m —  I kept getting errors saying that you shouldn't synthesize the bridge when extending from RCTEventEmitter.

@jasongaare we'll probably have to get Matt to look at some changes I made to Orientation.m. Not real strong on Objective-C. Let me know if you see any problems.